### PR TITLE
COMPASS-822: Remove lodash as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ const app = require('hadron-app');
 app.myObject = "testing";
 ```
 
-## Included dependencies
+## Included peerDependencies
 
 - hadron-app-registry
 - hadron-auto-update-manager

--- a/index.js
+++ b/index.js
@@ -1,13 +1,10 @@
-const _ = require('lodash');
-
 /**
  * The global app singleton.
  */
 const app = {
-  extend: function() {
-    const args = _.toArray(arguments);
+  extend: function(...args) {
     args.unshift(this);
-    return _.assign.apply(null, args);
+    return Object.assign.apply(null, args);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "precommit": [
     "check"
   ],
-  "dependencies": {
-    "lodash": "^3.10.1"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint-config-mongodb-js": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^3.10.1"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint-config-mongodb-js": "^2.2.0",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint-config-mongodb-js": "^2.2.0",
+    "mocha": "^3.2.0",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",
     "pre-commit": "^1.1.2"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,12 @@
+const app = require('../');
+const expect = require('chai').expect;
+
+
+describe('hadron-app', function() {
+  describe('extend', function() {
+    it('should be extenable', function() {
+      app.extend({foo: 'bar'});
+      expect(app).to.have.property('foo', 'bar');
+    });
+  });
+});


### PR DESCRIPTION
This PR removes `lodash` as a dependency in favor of using ES6 built-in language features. `hadron-app` must be required early in the application's initialization lifecycle, so removing external the external dependency avoids the performance hit of resolving and loading `lodash`. 

*Note* @durran `hadron-app` is currently published via your personal account.  Mind moving it to the mongodb-js npm org?